### PR TITLE
Adding a MDNS Service now uses the name if provided

### DIFF
--- a/src/QNMDNS.cpp
+++ b/src/QNMDNS.cpp
@@ -133,7 +133,7 @@ bool MDNSClass::addService(const char *name, const char *type,
     return false;
   }
 
-  int8_t slot = mdns_resp_add_service(netif_, hostname_.c_str(), type,
+  int8_t slot = mdns_resp_add_service(netif_, name, type,
                                       toProto(protocol), port, &srv_txt,
                                       reinterpret_cast<void *>(getTXTFunc));
   if (slot < 0 || maxServices() <= slot) {


### PR DESCRIPTION
Hi!
I noticed that adding a MDNS service with a custom service name still resulted in the MDNS reply to only contain the hostname.
I fixed the line, where creating the MDNS service in the LWIP still defaulted to the hostname. Now the response works as expected:

```
$ resolvectl --protocol=mdns service kcmcontrol._osc._tcp.local
kcmcontrol._osc._tcp.local: kcm88.local:8000 [priority=0, weight=0]
                            192.168.0.192                   -- link: enx644bf0333881
                            (kcmcontrol/_osc._tcp/local)
```

Previously, servicename and hostname were always identical:
```
$ resolvectl --protocol=mdns service kcmcontrol._osc._tcp.local
kcmcontrol._osc._tcp.local: kcmcontrol.local:8000 [priority=0, weight=0]
                            192.168.0.192                   -- link: enx644bf0333881
                            (kcmcontrol/_osc._tcp/local)
```

Thanks for your library! I'm having a blast using it in my piano controller so far :smile: 

Best,
Vivien